### PR TITLE
Add nonediag as tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@
 - [Melodyknit/YanXiBot](https://github.com/Melodyknit/YanXiBot): 为 AMV/MAD 创作者而制作的动漫资源查找机器人，且集成一些娱乐性功能
 - [HibiKier/zhenxun_bot ](https://github.com/HibiKier/zhenxun_bot): 可爱的绪山真寻 bot，实现了一些基础的功能和一些娱乐功能
 - [MeetWq/mybot](https://github.com/MeetWq/mybot): 机器人小Q，实现了一些乱七八糟的功能
+
+## 辅助工具
+
+- [NCBM/nonediag](https://github.com/NCBM/nonediag): NoneBot2 常见问题诊断工具，支持通过项目文件及日志分析错误


### PR DESCRIPTION
nonediag 是一个用于辅助诊断错误的工具。

目前支持以下类型的错误诊断：

- 模块/适配器缺失
- Python 版本不适配
- 错误导入抽象基类
- bot.py 手动导入检查及重复导入
- `nonebot.export` 检查
- 端口占用提示
